### PR TITLE
Ops/tests azure y script

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -7,20 +7,20 @@ on:
         
 
 jobs:
-    check_branches:
-      runs-on: ubuntu-latest
-      steps: 
-        - name: PR branches validation
-          run: |
-            if [[ "${{ github.event.pull_request.base.ref }}" == "main" && "${{ github.event.pull_request.head.ref }}" == feat/assignment-* ]]; then
-              echo "Branches are correct"
-              exit 0
-            else
-              echo "Error: Branch names are not correct."
-              exit 1
-            fi     
+    # check_branches:
+    #   runs-on: ubuntu-latest
+    #   steps: 
+    #     - name: PR branches validation
+    #       run: |
+    #         if [[ "${{ github.event.pull_request.base.ref }}" == "main" && "${{ github.event.pull_request.head.ref }}" == feat/assignment-* ]]; then
+    #           echo "Branches are correct"
+    #           exit 0
+    #         else
+    #           echo "Error: Branch names are not correct."
+    #           exit 1
+    #         fi     
     build:
-      needs: [check_branches]
+      # needs: [check_branches]
       uses: ./.github/workflows/main.yml
       secrets:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,8 @@
+import pytest
+
+def pytest_collection_modifyitems(config, items):
+    skip = pytest.mark.skip(reason="Fallan temporalmente solo porque ya no tenemos configurado azure")
+    
+    for item in items:
+        if "azure" in item.keywords:
+            item.add_marker(skip)

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,3 +4,4 @@ markers =
     unit: run only unit tests from flow and pl algorithms
     performance: run only performance tests from flow and pl algorithms
     integration: run only api tests
+    azure: tests that require azure credentials (directly or indirectly)

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Start testing db container
+docker run -d --rm \
+            -e POSTGRES_USER=postgres \
+            -e POSTGRES_PASSWORD=postgres \
+            -e POSTGRES_DB=postgres \
+            -p 5433:5432 \
+            --name postgres \
+            postgres:15
+exit_code=$?
+
+sleep 2
+
+if [[ $exit_code -eq 0 ]]; then
+    # Run all tests
+    #DATABASE_URL=postgresql://postgres:postgres@localhost:5433/postgres pytest
+    # Run selected tests (just like github actions)
+    #DATABASE_URL=postgresql://postgres:postgres@localhost:5433/postgres pytest -m "integration" --strict-markers --cov=src tests/ --cov-report=xml
+    DATABASE_URL=postgresql://postgres:postgres@localhost:5433/postgres poetry run pytest -m "integration" --strict-markers --cov=src tests/ --cov-report=xml
+
+else
+    echo "Error al iniciar el contenedor de db para tests."
+fi

--- a/tests/integration/api/groups/routes_test.py
+++ b/tests/integration/api/groups/routes_test.py
@@ -396,6 +396,7 @@ def test_add_reviewer(fastapi, tables):
 
 
 @pytest.mark.integration
+@pytest.mark.azure
 def test_post_groups_initial_project(fastapi, tables):
     # Arrange
     fastapi.app.dependency_overrides[get_email_sender] = override_get_email_sender
@@ -433,6 +434,7 @@ def test_post_groups_initial_project(fastapi, tables):
 
 
 @pytest.mark.integration
+@pytest.mark.azure
 def test_download_group_initial_project(fastapi):
     # Arrange
     helper = ApiHelper()
@@ -453,6 +455,7 @@ def test_download_group_initial_project(fastapi):
 
 
 @pytest.mark.integration
+@pytest.mark.azure
 def test_all_groups_initial_project_details(fastapi):
     # Arrange
     helper = ApiHelper()
@@ -583,6 +586,7 @@ def test_get_groups_by_id_being_tutor(fastapi, tables):
 
 
 @pytest.mark.integration
+@pytest.mark.azure
 def test_post_groups_final_project(fastapi, tables):
     # Arrange
     helper = ApiHelper()
@@ -619,6 +623,7 @@ def test_post_groups_final_project(fastapi, tables):
 
 
 @pytest.mark.integration
+@pytest.mark.azure
 def test_download_group_final_project(fastapi):
     # Arrange
     helper = ApiHelper()
@@ -639,6 +644,7 @@ def test_download_group_final_project(fastapi):
 
 
 @pytest.mark.integration
+@pytest.mark.azure
 def test_all_groups_final_project_details(fastapi):
     # Arrange
     helper = ApiHelper()
@@ -657,6 +663,7 @@ def test_all_groups_final_project_details(fastapi):
 
 
 @pytest.mark.integration
+@pytest.mark.azure
 def test_post_groups_intermediate_project(fastapi, tables):
     # Arrange
     helper = ApiHelper()
@@ -688,6 +695,7 @@ def test_post_groups_intermediate_project(fastapi, tables):
 
 
 @pytest.mark.integration
+@pytest.mark.azure
 def test_get_groups_intermediate_project(fastapi, tables):
     # Arrange
     helper = ApiHelper()
@@ -728,6 +736,7 @@ def test_get_groups_intermediate_project(fastapi, tables):
 
 
 @pytest.mark.integration
+@pytest.mark.azure
 def test_get_all_intermediate_project(fastapi, tables):
     # Arrange
     helper = ApiHelper()

--- a/tests/integration/core/azure_container_client_test.py
+++ b/tests/integration/core/azure_container_client_test.py
@@ -5,6 +5,7 @@ from src.core.azure_container_client import AzureContainerClient
 
 class TestAzureContainerClient:
     @pytest.mark.integration
+    @pytest.mark.azure
     def test_azure_container_client_exists(self):
         # Arrange
         container_name = api_config.container
@@ -15,6 +16,7 @@ class TestAzureContainerClient:
         assert az_client.exists() is True
 
     @pytest.mark.integration
+    @pytest.mark.azure
     def test_upload_test_file_to_azure(self):  # Arrange
         filename = "upload.txt"
         file_path = "tests/integration/core/upload.txt"
@@ -30,6 +32,7 @@ class TestAzureContainerClient:
         assert blob.blob_name == filename
 
     @pytest.mark.integration
+    @pytest.mark.azure
     def test_download_test_file_to_azure(self):  # Arrange
         filename = "test_data.txt"  # test_data is already in the storage
         expected_content = (
@@ -64,6 +67,7 @@ class TestAzureContainerClient:
             az_client.download(filename)
 
     @pytest.mark.integration
+    @pytest.mark.azure
     def test_list_blob_with_prefix_existence(self):
         # Arrange
         container_name = api_config.container
@@ -74,6 +78,7 @@ class TestAzureContainerClient:
         assert az_client.exists() is True
 
     @pytest.mark.integration
+    @pytest.mark.azure
     def test_upload_existing_test_file_to_azure(self):  # Arrange
         filename = "upload.txt"
         file_path = "tests/integration/core/upload.txt"
@@ -89,6 +94,7 @@ class TestAzureContainerClient:
         assert blob.blob_name == filename
 
     @pytest.mark.integration
+    @pytest.mark.azure
     def test_download_existing_test_file_to_azure(self):  # Arrange
         filename = "test_data.txt"  # test_data is already in the storage
         expected_content = (
@@ -123,6 +129,7 @@ class TestAzureContainerClient:
             az_client.download(filename)
 
     @pytest.mark.integration
+    @pytest.mark.azure
     def test_list_blob_with_prefix_length(self):
         # Arrange
         container_name = api_config.container
@@ -138,6 +145,7 @@ class TestAzureContainerClient:
         assert len(blobs) == 1
 
     @pytest.mark.integration
+    @pytest.mark.azure
     def test_list_blob_with_prefix_and_pattern(self):
         # Arrange
         container_name = api_config.container


### PR DESCRIPTION
### Excluyo temporalmente los tests sin credenciales, agrego script run_tests.py, CI on PRs

- Los **tests marcados con el marker @pytest.mark.azure**:
    - en `azure_container_client_test.py` usan las variables de entorno de azure directamente;
    - en `routes_test.py` usan endpoint get o post de la forma "groups/{group_id}/initial-project" (ídem intermediate y final project) que a su vez se conectan al almacenamiento de azure para cargar o descargar pdfs, usando las variables de entorno de azure también, indirectamente.

  Fallan porque actualmente no contamos con las credenciales de azure.
  **Cuando configuremos un nuevo entorno de despliegue con sus credenciales se los volverá a utilizar.**

- Agrego **script `run_tests.py` para correr los tests** (actualmente de integración) en local, de la misma forma que el CI en github actions.

- **Desactivo el checkeo de nombres de ramas del CI** al hacer PR, si más adelante acordamos una nomenclatura cuando tengamos el backlog lo podemos volver a activar.

